### PR TITLE
Fixed Android problems when opening the viewer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
 ## Props
 * source: `Object`
   * uri?: `string` - can be local or served on the web (ie. start withs `https://` or `file://`)
-  * base64?: `string` - should start with `data`
+  * base64?: `string` - should start with `data:application/pdf;base64,`. A base64 encoded pdf file tends to start with `JVBERi0xL` so your complete string should look soemthing like this: ``data:application/pdf;base64,JVBERi0xL...`
 * style: `object` - style props to override default container style
 * webviewStyle: `object` - style props to override default WebView style
 * onLoad: `func` - callback that runs after WebView is loaded

--- a/README.md
+++ b/README.md
@@ -80,3 +80,7 @@ const styles = StyleSheet.create({
 ## FAQ
 - [Why the component doesn't render PDF?](https://github.com/xcarpentier/rn-pdf-reader-js/issues/15#issuecomment-397306743)
 
+## Hire an expert!
+Looking for a ReactNative freelance expert with more than 12 years experience? Contact me from my [website](https://xaviercarpentier.com)!
+
+

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ const styles = StyleSheet.create({
   * uri?: `string` - can be local or served on the web (ie. start withs `https://` or `file://`)
   * base64?: `string` - should start with `data`
 * style: `object` - style props to override default container style
+* webviewStyle: `object` - style props to override default WebView style
+* onLoad: `func` - callback that runs after WebView is loaded
+* noLoader: `boolean` - show/hide the ActivityIndicator. Default is false
 
 ## Requirements
 * Use it into Expo app (from expo client, Standalone app or ExpoKit app).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
 ## Props
 * source: `Object`
   * uri?: `string` - can be local or served on the web (ie. start withs `https://` or `file://`)
-  * base64?: `string` - should start with `data:application/pdf;base64,`. A base64 encoded pdf file tends to start with `JVBERi0xL` so your complete string should look soemthing like this: ``data:application/pdf;base64,JVBERi0xL...`
+  * base64?: `string` - should start with `data:application/pdf;base64,`. A base64 encoded pdf file tends to start with `JVBERi0xL` so your complete string should look soemthing like this: `data:application/pdf;base64,JVBERi0xL...`
 * style: `object` - style props to override default container style
 * webviewStyle: `object` - style props to override default WebView style
 * onLoad: `func` - callback that runs after WebView is loaded

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@
   <a href="https://exp.host/@xcarpentier/rn-pdf-reader-example">💥 DEMO 💥</a>
 </p>
 
-## Next version
-
-`rn-pdf-reader-js@0.3.0-beta-0`
-
 ## Read a PDF just with JS (no native libs needed)
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -15,31 +15,38 @@
   <a href="https://exp.host/@xcarpentier/rn-pdf-reader-example">💥 DEMO 💥</a>
 </p>
 
+## Next version
+
+`rn-pdf-reader-js@0.3.0-beta-0`
+
 ## Read a PDF just with JS (no native libs needed)
 
 ## Limitations
+
 - **Display file only on full screen.**
-- **Embeded images binary are not display (yet) in Android** 
+- **Embeded images binary are not display (yet) in Android**
 
 [PRs are welcome...](https://github.com/xcarpentier/rn-pdf-reader-js/pulls)
 
 ## Example
 
 ```javascript
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import PDFReader from 'rn-pdf-reader-js';
-import { Constants } from 'expo';
+import React from 'react'
+import { StyleSheet, View } from 'react-native'
+import PDFReader from 'rn-pdf-reader-js'
+import { Constants } from 'expo'
 
 export default class App extends React.Component {
   render() {
     return (
       <View style={styles.container}>
         <PDFReader
-          source={{ uri: "http://gahp.net/wp-content/uploads/2017/09/sample.pdf" }}
+          source={{
+            uri: 'http://gahp.net/wp-content/uploads/2017/09/sample.pdf',
+          }}
         />
       </View>
-    );
+    )
   }
 }
 
@@ -49,38 +56,41 @@ const styles = StyleSheet.create({
     paddingTop: Constants.statusBarHeight,
     backgroundColor: '#ecf0f1',
   },
-});
+})
 ```
 
 ## Props
-* source: `Object`
-  * uri?: `string` - can be local or served on the web (ie. start withs `https://` or `file://`)
-  * base64?: `string` - should start with `data:application/pdf;base64,`. A base64 encoded pdf file tends to start with `JVBERi0xL` so your complete string should look soemthing like this: `data:application/pdf;base64,JVBERi0xL...`
-* style: `object` - style props to override default container style
-* webviewStyle: `object` - style props to override default WebView style
-* onLoad: `func` - callback that runs after WebView is loaded
-* noLoader: `boolean` - show/hide the ActivityIndicator. Default is false
+
+- source: `Object`
+  - uri?: `string` - can be local or served on the web (ie. start withs `https://` or `file://`)
+  - base64?: `string` - should start with `data:application/pdf;base64,`. A base64 encoded pdf file tends to start with `JVBERi0xL` so your complete string should look soemthing like this: `data:application/pdf;base64,JVBERi0xL...`
+- style: `object` - style props to override default container style
+- webviewStyle: `object` - style props to override default WebView style
+- onLoad: `func` - callback that runs after WebView is loaded
+- noLoader: `boolean` - show/hide the ActivityIndicator. Default is false
 
 ## Requirements
-* Use it into Expo app (from expo client, Standalone app or ExpoKit app).
-* Because we need to have access to `Expo.FileSystem`
-* Only React-Native 0.54+ support, Expo SDK 27
+
+- Use it into Expo app (from expo client, Standalone app or ExpoKit app).
+- Because we need to have access to `Expo.FileSystem`
+- Only React-Native 0.54+ support, Expo SDK 27
 
 ## Features
-* **For Android, use react-pdf / pdfjs in the webview**
-* For iOS devices, display file directly to the WebView
+
+- **For Android, use react-pdf / pdfjs in the webview**
+- For iOS devices, display file directly to the WebView
 
 ## What rn-pdf-reader-js use?
 
-* react-pdf (pdf.js)
-* WebView
-* Expo FileSystem API
-* Base64
+- react-pdf (pdf.js)
+- WebView
+- Expo FileSystem API
+- Base64
 
 ## FAQ
+
 - [Why the component doesn't render PDF?](https://github.com/xcarpentier/rn-pdf-reader-js/issues/15#issuecomment-397306743)
 
 ## Hire an expert!
+
 Looking for a ReactNative freelance expert with more than 12 years experience? Contact me from my [website](https://xaviercarpentier.com)!
-
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+declare module 'rn-pdf-reader-js' {
+  import { Component } from "react";
+  import { StyleProp, ViewStyle, NavState } from 'react-native';
+
+  interface IProps {
+    source: {
+      uri?: string,
+      base64?: string
+    },
+    style?: StyleProp<ViewStyle>,
+    webviewStyle?: StyleProp<ViewStyle>,
+    onLoad?: (event: NavState) => void,
+    noLoader?: boolean
+  }
+  
+  interface IState {
+    ready: boolean,
+    android: boolean,
+    ios: boolean,
+    data?: string,
+  }
+
+  export function removeFilesAsync(): Promise<void>;
+  
+  export default class PdfReader extends Component<IProps, IState> {}
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,17 +2,20 @@ declare module 'rn-pdf-reader-js' {
   import { Component } from "react";
   import { StyleProp, ViewStyle, NavState } from 'react-native';
 
+  interface ISource {
+    uri?: string;
+    base64?: string;
+    headers?: { [key: string]: string };
+  }
+
   interface IProps {
-    source: {
-      uri?: string,
-      base64?: string
-    },
+    source: ISource,
     style?: StyleProp<ViewStyle>,
     webviewStyle?: StyleProp<ViewStyle>,
     onLoad?: (event: NavState) => void,
     noLoader?: boolean
   }
-  
+
   interface IState {
     ready: boolean,
     android: boolean,
@@ -21,6 +24,6 @@ declare module 'rn-pdf-reader-js' {
   }
 
   export function removeFilesAsync(): Promise<void>;
-  
+
   export default class PdfReader extends Component<IProps, IState> {}
 }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ import {
   Platform,
   StyleSheet,
 } from 'react-native'
-import { FileSystem } from 'expo'
-import { Constants } from 'expo'
+import * as FileSystem from 'expo-file-system'
+import Constants from 'expo-constants'
 
 const {
   cacheDirectory,

--- a/index.js
+++ b/index.js
@@ -183,6 +183,7 @@ class PdfReader extends Component<Props, State> {
         <View style={[styles.container, style]}>
           {!ready && <Loader />}
           <WebView
+            onLoad={()=>this.setState({ready: true})}
             originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={styles.webview}
             source={{ uri: data }}

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 // @flow
 import React, { Component } from 'react'
 import {
-  WebView,
   View,
   ActivityIndicator,
   Platform,
   StyleSheet,
 } from 'react-native'
+import { WebView } from 'react-native-webview'
 import * as FileSystem from 'expo-file-system'
 import Constants from 'expo-constants'
 

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class PdfReader extends Component<Props, State> {
 
   render() {
     const { ready, data, ios, android } = this.state
-    const { style, webviewStyle, onLoad, noLoader } = this.props
+    const { style, webviewStyle, onLoad, noLoader, onLoadEnd, onError  } = this.props
 
     if (data && ios) {
       return (
@@ -210,6 +210,8 @@ class PdfReader extends Component<Props, State> {
         <View style={[styles.container, style]}>
           <WebView
             onLoad={onLoad}
+            onLoadEnd={onLoadEnd}
+            onError={onError}
             allowFileAccess
             originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={[styles.webview, webviewStyle]}

--- a/index.js
+++ b/index.js
@@ -211,6 +211,7 @@ class PdfReader extends Component<Props, State> {
           <WebView
             onLoad={onLoad}
             allowFileAccess
+            originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={[styles.webview, webviewStyle]}
             source={{ uri: htmlPath }}
             mixedContentMode="always"

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ class PdfReader extends Component<Props, State> {
       const android = Platform.OS === 'android'
 
       this.setState({ ios, android })
-
+      let ready = false
       let data = undefined
       if (
         source.uri &&
@@ -142,8 +142,10 @@ class PdfReader extends Component<Props, State> {
           source.uri.startsWith('content'))
       ) {
         data = await fetchPdfAsync(source.uri)
+        ready= !!data
       } else if (source.base64 && source.base64.startsWith('data')) {
         data = source.base64
+        ready = true
       } else if (ios) {
         data = source.uri
       } else {
@@ -155,7 +157,7 @@ class PdfReader extends Component<Props, State> {
         await writeWebViewReaderFileAsync(data)
       }
 
-      this.setState({ ready: !!data, data })
+      this.setState({ ready, data })
     } catch (error) {
       alert('Sorry, an error occurred.')
       console.error(error)
@@ -176,9 +178,10 @@ class PdfReader extends Component<Props, State> {
     const { ready, data, ios, android } = this.state
     const { style } = this.props
 
-    if (ready && data && ios) {
+    if (data && ios) {
       return (
         <View style={[styles.container, style]}>
+          {!ready && <Loader />}
           <WebView
             originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={styles.webview}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-pdf-reader-js",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "PDF reader for Expo",
   "main": "index.js",
   "author": "Xavier Carpentier <xcapetir@gmail.com> (https://xaviercarpentier.com/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-pdf-reader-js",
-  "version": "0.3.0-beta-0",
+  "version": "0.3.0",
   "description": "PDF reader for Expo",
   "main": "index.js",
   "author": "Xavier Carpentier <xcapetir@gmail.com> (https://xaviercarpentier.com/)",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "PDF reader for Expo",
   "main": "index.js",
+  "types": "index.d.ts",
   "author": "Xavier Carpentier <xcapetir@gmail.com> (https://xaviercarpentier.com/)",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-pdf-reader-js",
-  "version": "0.2.3",
+  "version": "0.3.0-beta-0",
   "description": "PDF reader for Expo",
   "main": "index.js",
   "author": "Xavier Carpentier <xcapetir@gmail.com> (https://xaviercarpentier.com/)",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "expo-constants": "*",
     "expo-file-system": "*",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-webview": "*"
   },
   "dependencies": {
     "buffer": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "peerDependencies": {
     "expo": "*",
+    "expo-constants": "*",
+    "expo-file-system": "*",
     "react": "*",
     "react-native": "*"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,11 +17,6 @@ crypto@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
 
-escape-string-regexp@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
 flow-bin@0.73.0:
   version "0.73.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
@@ -30,33 +25,6 @@ ieee754@^1.1.4:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
 
-invariant@2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
-
 js-base64@2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
-
-"js-tokens@^3.0.0 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
-
-react-native-webview@5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-5.12.0.tgz#e673f72a287829444ddcbc7ea2f28f2e5862f9fb"
-  integrity sha512-tdKBRgxq/DP6kg/B3tYoqmWiARY2BKTqbjFHJ8vH7TcThaPprlyWJyHuO54FfrS9dnPpU2H4C5i3btJvvy2OVQ==
-  dependencies:
-    escape-string-regexp "1.0.5"
-    invariant "2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,20 +17,6 @@ crypto@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
 
-expo-constants@*:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-5.0.1.tgz#597263397f269d7fe37d9cd6b30e305c16635a00"
-  integrity sha512-Ny3teALKaE/jFzBg6DHr2GOoHpwQ/OLs3q3VugZOoR6hXCeVcCEP9MyNvhgn/cheeBDAa6UIgarv2Yufb5RMqQ==
-  dependencies:
-    ua-parser-js "^0.7.19"
-
-expo-file-system@*:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-5.0.1.tgz#c26054e512c3bb2e256325b48e603957a24e6210"
-  integrity sha512-8AD8Tt0vR8XNIPXOg5akPUPGuf+SCiE9kY5JppUwfJtfIsiH3BZnebu1bkYCVOMojSgFA017kr8VmH57vEWdnQ==
-  dependencies:
-    uuid-js "^0.7.5"
-
 flow-bin@0.73.0:
   version "0.73.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
@@ -42,13 +28,3 @@ ieee754@^1.1.4:
 js-base64@2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
-
-ua-parser-js@^0.7.19:
-  version "0.7.20"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
-  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
-
-uuid-js@^0.7.5:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/uuid-js/-/uuid-js-0.7.5.tgz#6c886d02a53d2d40dcf25d91a170b4a7b25b94d0"
-  integrity sha1-bIhtAqU9LUDc8l2RoXC0p7JblNA=

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,11 @@ crypto@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
 
+escape-string-regexp@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
 flow-bin@0.73.0:
   version "0.73.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
@@ -25,6 +30,33 @@ ieee754@^1.1.4:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
 
+invariant@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 js-base64@2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
+
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+loose-envify@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
+react-native-webview@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-5.12.0.tgz#e673f72a287829444ddcbc7ea2f28f2e5862f9fb"
+  integrity sha512-tdKBRgxq/DP6kg/B3tYoqmWiARY2BKTqbjFHJ8vH7TcThaPprlyWJyHuO54FfrS9dnPpU2H4C5i3btJvvy2OVQ==
+  dependencies:
+    escape-string-regexp "1.0.5"
+    invariant "2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,20 @@ crypto@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
 
+expo-constants@*:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-5.0.1.tgz#597263397f269d7fe37d9cd6b30e305c16635a00"
+  integrity sha512-Ny3teALKaE/jFzBg6DHr2GOoHpwQ/OLs3q3VugZOoR6hXCeVcCEP9MyNvhgn/cheeBDAa6UIgarv2Yufb5RMqQ==
+  dependencies:
+    ua-parser-js "^0.7.19"
+
+expo-file-system@*:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-5.0.1.tgz#c26054e512c3bb2e256325b48e603957a24e6210"
+  integrity sha512-8AD8Tt0vR8XNIPXOg5akPUPGuf+SCiE9kY5JppUwfJtfIsiH3BZnebu1bkYCVOMojSgFA017kr8VmH57vEWdnQ==
+  dependencies:
+    uuid-js "^0.7.5"
+
 flow-bin@0.73.0:
   version "0.73.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
@@ -28,3 +42,13 @@ ieee754@^1.1.4:
 js-base64@2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
+
+ua-parser-js@^0.7.19:
+  version "0.7.20"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
+  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
+
+uuid-js@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/uuid-js/-/uuid-js-0.7.5.tgz#6c886d02a53d2d40dcf25d91a170b4a7b25b94d0"
+  integrity sha1-bIhtAqU9LUDc8l2RoXC0p7JblNA=


### PR DESCRIPTION
This fixes the problem indicated in next comment: https://github.com/xcarpentier/rn-pdf-reader-js/issues/69#issuecomment-536482614.
To work it needed permissions to read files plus the property allowFileAccessFromFileURLs from WebView, but we thought it might be more of an interesting idea if all the saving and loading data to and from a file were skipped, so the html is sent directly to the WebView.