### PR TITLE
Setting Color of Loader's ActivityIndicator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,8 @@ declare module 'rn-pdf-reader-js' {
     style?: StyleProp<ViewStyle>,
     webviewStyle?: StyleProp<ViewStyle>,
     onLoad?: (event: NavState) => void,
-    noLoader?: boolean
+    noLoader?: boolean,
+    colorLoader?: string
   }
 
   interface IState {

--- a/index.js
+++ b/index.js
@@ -75,9 +75,9 @@ async function urlToBlob(source: Source) {
   })
 }
 
-const Loader = () => (
+const Loader = (colorSpinner) => (
   <View style={{ flex: 1, justifyContent: 'center' }}>
-    <ActivityIndicator size="large" />
+    <ActivityIndicator size="large" color={colorSpinner.color}/>
   </View>
 )
 
@@ -104,7 +104,8 @@ type Props = {
   style: object,
   webviewStyle: object,
   onLoad: func,
-  noLoader: boolean
+  noLoader: boolean,
+  colorLoader: String
 }
 
 type State = {
@@ -163,7 +164,7 @@ class PdfReader extends Component<Props, State> {
 
   render() {
     const { ready, data, ios, android } = this.state
-    const { style, webviewStyle, onLoad, noLoader, onLoadEnd, onError  } = this.props
+    const { style, webviewStyle, onLoad, noLoader, onLoadEnd, onError, colorLoader } = this.props
 
     if (data && ios) {
       return (
@@ -201,7 +202,7 @@ class PdfReader extends Component<Props, State> {
       )
     }
 
-    return (<View style={[styles.container, style]}>{!noLoader && !ready && <Loader />}</View>)
+    return (<View style={[styles.container, style]}>{!noLoader && !ready && <Loader color={colorLoader} />}</View>)
   }
 }
 


### PR DESCRIPTION
fix: Added attribute "colorLoader" in PdfReader.

- Since default color of ActivityIndicator is "gray", it might not be visible in several context. Therefore, it is necessary to enable personalize loading icon color.

Include new optional attribute colorLoader that's passed to const Loader in index.js